### PR TITLE
Fix condition causing missing vertical GridLines.

### DIFF
--- a/graphics.go
+++ b/graphics.go
@@ -140,7 +140,7 @@ func drawXTics(bg BasicGraphics, rng Range, y, ym, ticLen int, options PlotOptio
 	if rng.TicSetting.Grid > GridOff {
 		for ticcnt, tic := range rng.Tics {
 			x := rng.Data2Screen(tic.Pos)
-			if ticcnt > 0 && ticcnt < len(rng.Tics)-1 && rng.TicSetting.Grid == GridLines {
+			if ticcnt >= 0 && ticcnt <= len(rng.Tics)-1 && rng.TicSetting.Grid == GridLines {
 				// fmt.Printf("Gridline at x=%d\n", x)
 				bg.Line(x, y-1, x, ym+1, elementStyle(options, GridLineElement))
 			} else if rng.TicSetting.Grid == GridBlocks {


### PR DESCRIPTION
(issuing pull request from branch).

This patch fixes a boundary condition during vertical GridLine
calculation. The previous version used strict less-than condition. When
the min and max values fall on even multiples of the tic delta, the
absence of the GridLines is not noticeable. However, when the min and
max values do not fall on even multiples of the tic delta, the first and
last grid line are missing.

By changing the condition to use less-than-or-equal, the first and last
grid lines are included on the display.

![Before](https://cloud.githubusercontent.com/assets/1085316/2639621/04199ebc-becf-11e3-8cdc-0a0b15561999.png)

![After](https://cloud.githubusercontent.com/assets/1085316/2639623/0fa3f412-becf-11e3-9c85-1cf7351b2df0.png)
