### PR TITLE
Update draw2d repo

### DIFF
--- a/imgg/image.go
+++ b/imgg/image.go
@@ -1,7 +1,7 @@
 package imgg
 
 import (
-	"code.google.com/p/draw2d/draw2d"
+	"github.com/llgcode/draw2d"
 	"code.google.com/p/freetype-go/freetype"
 	"code.google.com/p/freetype-go/freetype/raster"
 	"code.google.com/p/freetype-go/freetype/truetype"


### PR DESCRIPTION
The old code.google.com repo will be deleted. The github draw2d repo has now also a new pdf backend. You can use this to generate with the same draw2d code pdf charts.

For a demo pdf output see:
- https://raw.githubusercontent.com/llgcode/draw2d/master/resource/image/geometry.pdf
- https://raw.githubusercontent.com/llgcode/draw2d/master/resource/image/postscript.pdf