### PR TITLE
fixing issue 27: now SVG graphics are correct for PieCharts >180°

### DIFF
--- a/svgg/svg.go
+++ b/svgg/svg.go
@@ -399,7 +399,9 @@ func (sg *SvgGraphics) Rings(wedges []chart.Wedgeinfo, x, y, ro, ri int) {
 			d += fmt.Sprintf("L %d,%d ", int(rf*cphi+0.5+dx)+x, int(rf*sphi+0.5+dy)+y)
 
 			dx, dy = p*math.Cos(w.Psi-math.Pi/2), p*math.Sin(w.Psi-math.Pi/2)
-			d += fmt.Sprintf("A %d,%d 0 0 1 %d,%d ", ro, ro, int(rf*cpsi+0.5+dx)+x, int(rf*spsi+0.5+dy)+y)
+			if math.Abs(w.Phi-w.Psi)>math.Pi {
+				d += fmt.Sprintf("A %d,%d 0 1 1 %d,%d ", ro, ro, int(rf*cpsi+0.5+dx)+x, int(rf*spsi+0.5+dy)+y) } else {
+				d += fmt.Sprintf("A %d,%d 0 0 1 %d,%d ", ro, ro, int(rf*cpsi+0.5+dx)+x, int(rf*spsi+0.5+dy)+y) } 
 			d += fmt.Sprintf("z")
 		} else {
 			// ring drawn as inner radius -> outer radius -> outer arc -> inner radius -> inner arc
@@ -410,9 +412,13 @@ func (sg *SvgGraphics) Rings(wedges []chart.Wedgeinfo, x, y, ro, ri int) {
 			d += fmt.Sprintf("L %d,%d ", int(rof*cphi+0.5+dx)+x, int(rof*sphi+0.5+dy)+y)
 
 			dx, dy = p*math.Cos(w.Psi-math.Pi/2), p*math.Sin(w.Psi-math.Pi/2)
-			d += fmt.Sprintf("A %d,%d 0 0 1 %d,%d ", ro, ro, int(rof*cpsi+0.5+dx)+x, int(rof*spsi+0.5+dy)+y)
+			if math.Abs(w.Phi-w.Psi)>math.Pi {
+				d += fmt.Sprintf("A %d,%d 0 1 1 %d,%d ", ro, ro, int(rof*cpsi+0.5+dx)+x, int(rof*spsi+0.5+dy)+y) } else {
+				d += fmt.Sprintf("A %d,%d 0 0 1 %d,%d ", ro, ro, int(rof*cpsi+0.5+dx)+x, int(rof*spsi+0.5+dy)+y) } 
 			d += fmt.Sprintf("L %d,%d ", int(rif*cpsi+0.5+dx)+x, int(rif*spsi+0.5+dy)+y)
-			d += fmt.Sprintf("A %d,%d 0 0 0 %d,%d ", ri, ri, a, b)
+			if math.Abs(w.Phi-w.Psi)>math.Pi {
+				d += fmt.Sprintf("A %d,%d 0 1 0 %d,%d ", ri, ri, a, b) } else {
+				d += fmt.Sprintf("A %d,%d 0 0 0 %d,%d ", ri, ri, a, b) }
 			d += fmt.Sprintf("z")
 
 		}


### PR DESCRIPTION
fixes https://github.com/vdobler/chart/issues/27

In the code there is now a comparison which sets the "large-arc-flag" if needed as described in the [SVG documenation](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#Arcs). 

Examples of plots:

<img width="805" alt="Schnappschuss (2019-07-24 18 18 33)" src="https://user-images.githubusercontent.com/5817273/61810417-7d4ece00-ae3f-11e9-8add-19d948b0414c.png">
<img width="830" alt="Schnappschuss (2019-07-24 18 18 13)" src="https://user-images.githubusercontent.com/5817273/61810418-7d4ece00-ae3f-11e9-9465-eb7e09819dc4.png">
